### PR TITLE
Fixed bug where URL didnt point to the correct URL when hosted on github

### DIFF
--- a/webapp/src/app/home/home.component.ts
+++ b/webapp/src/app/home/home.component.ts
@@ -62,7 +62,7 @@ export class HomeComponent
         this.addToUrl('image');
         this.addToUrl('color');
 
-        this.url = `${ currentDomain }/${ this.url }`.replaceAll(' ', '%20');
+        this.url = `${ currentDomain }/happy-birthday-message/${ this.url }`.replaceAll(' ', '%20');
         this.showUrl = true;
     }
 


### PR DESCRIPTION
Bug: 
The generated URL contained the URL
https://rubenfern.github.io/message
When the correct display URL is
https://rubenfern.github.io/happy-birthday-message/message